### PR TITLE
Adhere to standard reader/writer interface conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 ![Linux Port Iteration Result](assets/Linux_Iteration_Demo.png)
 
-Cross-platform serial port library, with convenient poll/read/write interface.
+Cross-platform serial port library, adhering to the standard library's reader
+and writer interface. All poll (peek) and flush (discard/flush) operations are
+accessible through `std.Io.Reader` and `std.Io.Writer` respectively.
+
 Kept up to date to work with latest Zig stable release (0.15.1).
 
 ## Todo
@@ -59,11 +62,19 @@ const timeout = 1_000 * std.time.ns_per_ms;
 var timer = try std.time.Timer.start();
 // Keep polling and reading until no bytes arrive for 1000ms.
 while (timer.read() < timeout) {
-  if (try port.poll()) {
-    const read_size = try reader.interface.readSliceShort(&result_buffer);
-    std.log.info("Port bytes arrived: {any}", .{result_buffer[0..read_size]});
-    timer.reset();
-  }
+  // Standard reader's "peek" functions replace the function of poll.
+  _ = reader.interface.peekByte() catch |e| switch(e) {
+    error.EndOfStream => continue,
+    else => return e,
+  };
+
+  // ...
+
+  // Or, you can directly attempt a read and loop if no bytes are found.
+  const read_size = try reader.interface.readSliceShort(&result_buffer);
+  if (read_size == 0) continue;
+  std.log.info("Port bytes arrived: {any}", .{result_buffer[0..read_size]});
+  timer.reset();
 }
 // ...
 ```

--- a/src/backend/linux.zig
+++ b/src/backend/linux.zig
@@ -166,62 +166,6 @@ pub fn configureFlowControl(
     termios.iflag.IXOFF = flow_control == .software;
 }
 
-pub fn flush(port: std.fs.File, options: serialport.FlushOptions) !void {
-    if (!options.input and !options.output) return;
-
-    const TCIFLUSH = 0;
-    const TCOFLUSH = 1;
-    const TCIOFLUSH = 2;
-    const TCFLSH = 0x540B;
-
-    const result = linux.syscall3(
-        .ioctl,
-        @bitCast(@as(isize, @intCast(port.handle))),
-        TCFLSH,
-        if (options.input and options.output)
-            TCIOFLUSH
-        else if (options.input)
-            TCIFLUSH
-        else
-            TCOFLUSH,
-    );
-    // Use `linux.E.init` rather than `std.posix.errno`, as `std.posix.errno`
-    // abstraction will not be set by syscall if libc is linked
-    return switch (linux.E.init(result)) {
-        .SUCCESS => {},
-        .BADF => error.FileNotFound,
-        .NOTTY => error.FileNotTty,
-        else => unreachable,
-    };
-}
-
-test "flush error handling" {
-    var f: std.fs.File = try std.fs.cwd().createFile("temp.txt", .{});
-    defer std.fs.cwd().deleteFile("temp.txt") catch {};
-    defer f.close();
-
-    try std.testing.expectError(
-        error.FileNotTty,
-        flush(f, .{ .input = true, .output = true }),
-    );
-}
-
-pub fn poll(port: std.fs.File) !bool {
-    var pollfds: [1]linux.pollfd = .{.{
-        .fd = port.handle,
-        .events = linux.POLL.IN,
-        .revents = undefined,
-    }};
-    if (linux.poll(&pollfds, 1, 0) == 0) return false;
-
-    if (pollfds[0].revents & linux.POLL.IN == 0) return false;
-
-    const err_mask = linux.POLL.ERR | linux.POLL.NVAL | linux.POLL.HUP;
-    if (pollfds[0].revents & err_mask != 0) return false;
-
-    return true;
-}
-
 pub fn iterate() !Iterator {
     var result: Iterator = .{
         .dir = std.fs.cwd().openDir(
@@ -320,30 +264,52 @@ test "software flow control" {
     const orig_slave = try configure(slave, config);
     defer std.posix.tcsetattr(slave.handle, .NOW, orig_slave) catch {};
 
-    try std.testing.expectEqual(false, try poll(slave));
-    try std.testing.expectEqual(12, try master.write("test message"));
-    try std.testing.expectEqual(true, try poll(slave));
+    var master_w = master.writerStreaming(&.{});
+    var reader_buf: [128]u8 = undefined;
+    var slave_r = slave.readerStreaming(&reader_buf);
+
+    try std.testing.expectError(
+        error.EndOfStream,
+        slave_r.interface.peekByte(),
+    );
+    try master_w.interface.writeAll("test message");
+    try std.testing.expectEqual('t', try slave_r.interface.peekByte());
 
     var buffer: [16]u8 = undefined;
-    try std.testing.expectEqual(12, try slave.read(&buffer));
+    try std.testing.expectEqual(
+        12,
+        try slave_r.interface.readSliceShort(&buffer),
+    );
     try std.testing.expectEqualSlices(u8, "test message", buffer[0..12]);
-    try std.testing.expectEqual(false, try poll(slave));
+    try std.testing.expectError(
+        error.EndOfStream,
+        slave_r.interface.peekByte(),
+    );
 
-    try std.testing.expectEqual(12, try master.write("test message"));
-    try std.testing.expectEqual(true, try poll(slave));
+    try master_w.interface.writeAll("test message");
+    try std.testing.expectEqual('t', try slave_r.interface.peekByte());
 
     var small_buffer: [8]u8 = undefined;
-    try std.testing.expectEqual(8, try slave.read(&small_buffer));
+    try slave_r.interface.readSliceAll(&small_buffer);
     try std.testing.expectEqualSlices(u8, "test mes", &small_buffer);
-    try std.testing.expectEqual(true, try poll(slave));
-    try std.testing.expectEqual(4, try slave.read(&small_buffer));
+    try std.testing.expectEqual('s', try slave_r.interface.peekByte());
+    try std.testing.expectEqual(
+        4,
+        try slave_r.interface.readSliceShort(&small_buffer),
+    );
     try std.testing.expectEqualSlices(u8, "sage", small_buffer[0..4]);
-    try std.testing.expectEqual(false, try poll(slave));
+    try std.testing.expectEqual(
+        error.EndOfStream,
+        slave_r.interface.peekByte(),
+    );
 
-    try std.testing.expectEqual(12, try master.write("test message"));
-    try std.testing.expectEqual(true, try poll(slave));
-    try flush(slave, .{ .input = true });
-    try std.testing.expectEqual(false, try poll(slave));
+    try master_w.interface.writeAll("test message");
+    try std.testing.expectEqual('t', try slave_r.interface.peekByte());
+    try std.testing.expectEqual(12, try slave_r.interface.discardRemaining());
+    try std.testing.expectEqual(
+        error.EndOfStream,
+        slave_r.interface.peekByte(),
+    );
 }
 
 test {
@@ -359,30 +325,51 @@ test {
     const orig_slave = try configure(slave, config);
     defer std.posix.tcsetattr(slave.handle, .NOW, orig_slave) catch {};
 
-    try std.testing.expectEqual(false, try poll(slave));
-    try std.testing.expectEqual(12, try master.write("test message"));
-    try std.testing.expectEqual(true, try poll(slave));
+    var master_w = master.writerStreaming(&.{});
+    var reader_buf: [128]u8 = undefined;
+    var slave_r = slave.readerStreaming(&reader_buf);
+
+    try std.testing.expectError(
+        error.EndOfStream,
+        slave_r.interface.peekByte(),
+    );
+    try master_w.interface.writeAll("test message");
+    try std.testing.expectEqual('t', try slave_r.interface.peekByte());
 
     var buffer: [16]u8 = undefined;
-    try std.testing.expectEqual(12, try slave.read(&buffer));
+    try std.testing.expectEqual(
+        12,
+        try slave_r.interface.readSliceShort(&buffer),
+    );
     try std.testing.expectEqualSlices(u8, "test message", buffer[0..12]);
-    try std.testing.expectEqual(false, try poll(slave));
-
-    try std.testing.expectEqual(12, try master.write("test message"));
-    try std.testing.expectEqual(true, try poll(slave));
+    try std.testing.expectError(
+        error.EndOfStream,
+        slave_r.interface.peekByte(),
+    );
+    try master_w.interface.writeAll("test message");
+    try std.testing.expectEqual('t', slave_r.interface.peekByte());
 
     var small_buffer: [8]u8 = undefined;
-    try std.testing.expectEqual(8, try slave.read(&small_buffer));
+    try slave_r.interface.readSliceAll(&small_buffer);
     try std.testing.expectEqualSlices(u8, "test mes", &small_buffer);
-    try std.testing.expectEqual(true, try poll(slave));
-    try std.testing.expectEqual(4, try slave.read(&small_buffer));
+    try std.testing.expectEqual('s', slave_r.interface.peekByte());
+    try std.testing.expectEqual(
+        4,
+        slave_r.interface.readSliceShort(&small_buffer),
+    );
     try std.testing.expectEqualSlices(u8, "sage", small_buffer[0..4]);
-    try std.testing.expectEqual(false, try poll(slave));
+    try std.testing.expectError(
+        error.EndOfStream,
+        slave_r.interface.peekByte(),
+    );
 
-    try std.testing.expectEqual(12, try master.write("test message"));
-    try std.testing.expectEqual(true, try poll(slave));
-    try flush(slave, .{ .input = true });
-    try std.testing.expectEqual(false, try poll(slave));
+    try master_w.interface.writeAll("test message");
+    try std.testing.expectEqual('t', try slave_r.interface.peekByte());
+    try std.testing.expectEqual(12, try slave_r.interface.discardRemaining());
+    try std.testing.expectError(
+        error.EndOfStream,
+        slave_r.interface.peekByte(),
+    );
 }
 
 test "nonblock read" {
@@ -398,8 +385,14 @@ test "nonblock read" {
     const orig_slave = try configure(slave, config);
     defer std.posix.tcsetattr(slave.handle, .NOW, orig_slave) catch {};
 
+    var reader_buf: [128]u8 = undefined;
+    var slave_r = slave.readerStreaming(&reader_buf);
+
     var result: [16]u8 = undefined;
-    try std.testing.expectEqual(0, try slave.read(&result));
+    try std.testing.expectEqual(
+        0,
+        try slave_r.interface.readSliceShort(&result),
+    );
 }
 
 test "custom baud rate" {
@@ -415,28 +408,53 @@ test "custom baud rate" {
     const orig_slave = try configure(slave, config);
     defer std.posix.tcsetattr(slave.handle, .NOW, orig_slave) catch {};
 
-    try std.testing.expectEqual(false, try poll(slave));
-    try std.testing.expectEqual(12, try master.write("test message"));
-    try std.testing.expectEqual(true, try poll(slave));
+    var master_w = master.writerStreaming(&.{});
+    var reader_buf: [128]u8 = undefined;
+    var slave_r = slave.readerStreaming(&reader_buf);
+
+    try std.testing.expectError(
+        error.EndOfStream,
+        slave_r.interface.peekByte(),
+    );
+    try master_w.interface.writeAll("test message");
+    try std.testing.expectEqual('t', slave_r.interface.peekByte());
 
     var buffer: [16]u8 = undefined;
-    try std.testing.expectEqual(12, try slave.read(&buffer));
+    try std.testing.expectEqual(
+        12,
+        try slave_r.interface.readSliceShort(&buffer),
+    );
     try std.testing.expectEqualSlices(u8, "test message", buffer[0..12]);
-    try std.testing.expectEqual(false, try poll(slave));
+    try std.testing.expectEqual(
+        error.EndOfStream,
+        slave_r.interface.peekByte(),
+    );
 
-    try std.testing.expectEqual(12, try master.write("test message"));
-    try std.testing.expectEqual(true, try poll(slave));
+    try master_w.interface.writeAll("test message");
+    try std.testing.expectEqual('t', try slave_r.interface.peekByte());
 
     var small_buffer: [8]u8 = undefined;
-    try std.testing.expectEqual(8, try slave.read(&small_buffer));
+    try std.testing.expectEqual(
+        8,
+        try slave_r.interface.readSliceShort(&small_buffer),
+    );
     try std.testing.expectEqualSlices(u8, "test mes", &small_buffer);
-    try std.testing.expectEqual(true, try poll(slave));
-    try std.testing.expectEqual(4, try slave.read(&small_buffer));
+    try std.testing.expectEqual('s', try slave_r.interface.peekByte());
+    try std.testing.expectEqual(
+        4,
+        try slave_r.interface.readSliceShort(&small_buffer),
+    );
     try std.testing.expectEqualSlices(u8, "sage", small_buffer[0..4]);
-    try std.testing.expectEqual(false, try poll(slave));
+    try std.testing.expectError(
+        error.EndOfStream,
+        slave_r.interface.peekByte(),
+    );
 
-    try std.testing.expectEqual(12, try master.write("test message"));
-    try std.testing.expectEqual(true, try poll(slave));
-    try flush(slave, .{ .input = true });
-    try std.testing.expectEqual(false, try poll(slave));
+    try master_w.interface.writeAll("test message");
+    try std.testing.expectEqual('t', try slave_r.interface.peekByte());
+    try std.testing.expectEqual(12, try slave_r.interface.discardRemaining());
+    try std.testing.expectError(
+        error.EndOfStream,
+        slave_r.interface.peekByte(),
+    );
 }

--- a/src/backend/macos.zig
+++ b/src/backend/macos.zig
@@ -90,42 +90,6 @@ pub fn configureFlowControl(
     termios.iflag.IXOFF = flow_control == .software;
 }
 
-pub fn flush(port: std.fs.File, options: serialport.FlushOptions) !void {
-    if (!options.input and !options.output) return;
-    const result = c.tcflush(
-        port.handle,
-        if (options.input and options.output)
-            c.TCIOFLUSH
-        else if (options.input)
-            c.TCIFLUSH
-        else
-            c.TCOFLUSH,
-    );
-    return switch (std.posix.errno(result)) {
-        .SUCCESS => {},
-        .BADF => error.FileNotFound,
-        .NOTTY => error.FileNotTty,
-        else => unreachable,
-    };
-}
-
-pub fn poll(port: std.fs.File) !bool {
-    var pollfds: [1]std.posix.pollfd = .{
-        .{
-            .fd = port.handle,
-            .events = std.posix.POLL.IN,
-            .revents = undefined,
-        },
-    };
-    if (try std.posix.poll(&pollfds, 0) == 0) return false;
-    if (pollfds[0].revents & std.posix.POLL.IN == 0) return false;
-
-    const err_mask = std.posix.POLL.ERR | std.posix.POLL.NVAL |
-        std.posix.POLL.HUP;
-    if (pollfds[0].revents & err_mask != 0) return false;
-    return true;
-}
-
 pub fn iterate() !Iterator {
     var result: Iterator = .{
         .dir = try std.fs.cwd().openDir("/dev", .{ .iterate = true }),

--- a/src/backend/windows.zig
+++ b/src/backend/windows.zig
@@ -22,12 +22,6 @@ pub const BaudRate = enum(windows.DWORD) {
     _,
 };
 
-/// Reused structures necessary between non-blocking poll calls.
-pub const PollContinuation = struct {
-    events: EventMask,
-    overlapped: windows.OVERLAPPED,
-};
-
 pub const ReadError =
     windows.ReadFileError ||
     windows.OpenError ||
@@ -115,75 +109,6 @@ pub fn configure(port: std.fs.File, config: serialport.Config) !void {
     };
     if (SetCommTimeouts(port.handle, &timeouts) == 0) {
         return windows.unexpectedError(windows.GetLastError());
-    }
-}
-
-pub fn flush(port: std.fs.File, options: serialport.FlushOptions) !void {
-    if (!options.input and !options.output) return;
-    if (PurgeComm(port.handle, .{
-        .PURGE_TXCLEAR = options.output,
-        .PURGE_RXCLEAR = options.input,
-    }) == 0) {
-        return windows.unexpectedError(windows.GetLastError());
-    }
-}
-
-pub fn poll(port: std.fs.File, continuation: *?PollContinuation) !bool {
-    var comstat: ComStat = undefined;
-    if (ClearCommError(port.handle, null, &comstat) == 0) {
-        return windows.unexpectedError(windows.GetLastError());
-    }
-    if (comstat.cbInQue > 0) return true;
-
-    if (continuation.*) |*cont| {
-        if (windows.GetOverlappedResult(
-            port.handle,
-            &cont.overlapped,
-            false,
-        ) catch |e| switch (e) {
-            error.WouldBlock => return false,
-            else => return e,
-        } != 0) {
-            const was_rx = cont.events.RXCHAR;
-            continuation.* = null;
-            return was_rx;
-        } else {
-            switch (windows.GetLastError()) {
-                windows.Win32Error.IO_PENDING => return false,
-                else => |e| return windows.unexpectedError(e),
-            }
-        }
-    } else {
-        continuation.* = .{
-            .events = undefined,
-            .overlapped = .{
-                .Internal = 0,
-                .InternalHigh = 0,
-                .DUMMYUNIONNAME = .{
-                    .DUMMYSTRUCTNAME = .{
-                        .Offset = 0,
-                        .OffsetHigh = 0,
-                    },
-                },
-                .hEvent = try windows.CreateEventEx(
-                    null,
-                    "",
-                    windows.CREATE_EVENT_MANUAL_RESET,
-                    windows.EVENT_ALL_ACCESS,
-                ),
-            },
-        };
-        if (WaitCommEvent(
-            port.handle,
-            &continuation.*.?.events,
-            &continuation.*.?.overlapped,
-        ) == 0) {
-            switch (windows.GetLastError()) {
-                windows.Win32Error.IO_PENDING => return false,
-                else => |e| return windows.unexpectedError(e),
-            }
-        }
-        return continuation.*.?.events.RXCHAR;
     }
 }
 

--- a/src/serialport.zig
+++ b/src/serialport.zig
@@ -29,7 +29,6 @@ const PortImpl = switch (builtin.target.os.tag) {
     },
     .windows => struct {
         file: std.fs.File,
-        poll_continuation: ?windows.PollContinuation = null,
     },
     else => @compileError("unsupported OS"),
 };
@@ -96,30 +95,9 @@ pub const Port = struct {
         }
     }
 
-    pub fn flush(self: *@This(), options: FlushOptions) !void {
-        switch (comptime builtin.target.os.tag) {
-            .linux, .macos, .windows => try backend.flush(
-                self._impl.file,
-                options,
-            ),
-            else => @compileError("unsupported OS"),
-        }
-    }
-
-    pub fn poll(self: *@This()) !bool {
-        switch (comptime builtin.target.os.tag) {
-            .linux, .macos => return backend.poll(self._impl.file),
-            .windows => return windows.poll(
-                self._impl.file,
-                &self._impl.poll_continuation,
-            ),
-            else => @compileError("unsupported OS"),
-        }
-    }
-
     pub fn reader(self: @This(), buffer: []u8) Reader {
         switch (comptime builtin.target.os.tag) {
-            .linux, .macos => return self._impl.file.reader(buffer),
+            .linux, .macos => return self._impl.file.readerStreaming(buffer),
             .windows => return windows.reader(self._impl.file, buffer),
             else => @compileError("unsupported OS"),
         }
@@ -127,7 +105,7 @@ pub const Port = struct {
 
     pub fn writer(self: @This(), buffer: []u8) Writer {
         switch (comptime builtin.target.os.tag) {
-            .linux, .macos => return self._impl.file.writer(buffer),
+            .linux, .macos => return self._impl.file.writerStreaming(buffer),
             .windows => return windows.writer(self._impl.file, buffer),
             else => @compileError("unsupported OS"),
         }


### PR DESCRIPTION
The old approach of providing a poll/flush implementation in backends held duplicate functionality with the standard library reader/writer interface. Moreover, the lack of checking the reader buffer during poll and discarding the reader/writer buffer during flush allowed for some footguns with the new reader/writer interface usage.

As such, the poll/flush implementations have been removed, instead favoring the methods already provided in the standard interfaces.