### PR TITLE
Upgrade 0.16.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.1
+          version: 0.16.0
 
       - name: Run zig fmt
         if: matrix.os == 'ubuntu-latest'

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .serialport,
     .version = "0.2.1",
     .fingerprint = 0xe5e4c9be883af1c3,
-    .minimum_zig_version = "0.15.2",
+    .minimum_zig_version = "0.16.0",
     .dependencies = .{},
     .paths = .{
         "build.zig",

--- a/src/backend/linux.zig
+++ b/src/backend/linux.zig
@@ -5,17 +5,12 @@ const linux = std.os.linux;
 
 pub const BaudRate = b: {
     const ti = @typeInfo(linux.speed_t).@"enum";
-    var baud_rate_ti: std.builtin.Type.Enum = .{
-        .tag_type = ti.tag_type,
-        .fields = undefined,
-        .decls = &.{},
-        .is_exhaustive = false,
-    };
-    var fields: [ti.fields.len]std.builtin.Type.EnumField = undefined;
     @setEvalBranchQuota(3_874);
+    var field_names: [ti.fields.len][]const u8 = undefined;
+    var field_values: [ti.fields.len]ti.tag_type = undefined;
     for (ti.fields, 0..) |field, i| {
-        fields[i].name = field.name;
-        fields[i].value = std.fmt.parseInt(
+        field_names[i] = field.name;
+        field_values[i] = std.fmt.parseInt(
             ti.tag_type,
             field.name[1..],
             10,
@@ -23,23 +18,25 @@ pub const BaudRate = b: {
             @compileError("invalid baud rate tag");
         };
     }
-    baud_rate_ti.fields = &fields;
-    break :b @Type(std.builtin.Type{ .@"enum" = baud_rate_ti });
+    break :b @Enum(ti.tag_type, .nonexhaustive, &field_names, &field_values);
 };
 
-pub fn open(path: []const u8, flags: std.fs.File.OpenFlags) !std.fs.File {
-    var result = try std.fs.cwd().openFile(path, flags);
+pub fn open(
+    io: std.Io,
+    path: []const u8,
+    flags: std.Io.File.OpenFlags,
+) std.Io.File.OpenError!std.Io.File {
+    var result = try std.Io.Dir.cwd().openFile(io, path, flags);
     errdefer result.close();
-
-    var fl_flags = try std.posix.fcntl(result.handle, std.posix.F.GETFL, 0);
+    var fl_flags = std.os.linux.fcntl(result.handle, std.os.linux.F.GETFL, 0);
     fl_flags |= @as(usize, 1 << @bitOffsetOf(std.posix.O, "NONBLOCK"));
-    _ = try std.posix.fcntl(result.handle, std.posix.F.SETFL, fl_flags);
+    _ = std.os.linux.fcntl(result.handle, std.os.linux.F.SETFL, 0);
     return result;
 }
 
 /// Configure serial port. Returns original `termios` settings on success.
 pub fn configure(
-    port: std.fs.File,
+    port: std.Io.File,
     config: serialport.Config,
 ) !linux.termios {
     var settings = try std.posix.tcgetattr(port.handle);
@@ -166,9 +163,10 @@ pub fn configureFlowControl(
     termios.iflag.IXOFF = flow_control == .software;
 }
 
-pub fn iterate() !Iterator {
+pub fn iterate(io: std.Io) !Iterator {
     var result: Iterator = .{
-        .dir = std.fs.cwd().openDir(
+        .dir = std.Io.Dir.cwd().openDir(
+            io,
             "/dev/serial/by-id",
             .{ .iterate = true },
         ) catch |e| switch (e) {
@@ -184,42 +182,45 @@ pub fn iterate() !Iterator {
 }
 
 pub const Iterator = struct {
-    dir: ?std.fs.Dir,
-    iterator: std.fs.Dir.Iterator,
+    dir: ?std.Io.Dir,
+    iterator: std.Io.Dir.Iterator,
     name_buffer: [256]u8 = undefined,
-    path_buffer: [std.fs.max_path_bytes]u8 = undefined,
+    path_buffer: [std.Io.Dir.max_path_bytes]u8 = undefined,
 
-    pub fn next(self: *@This()) !?serialport.Stub {
+    pub fn next(self: *@This(), io: std.Io) !?serialport.Stub {
         if (self.dir == null) return null;
 
         var result: serialport.Stub = undefined;
-        while (try self.iterator.next()) |entry| {
+        while (try self.iterator.next(io)) |entry| {
             if (entry.kind != .sym_link) continue;
             @memcpy(self.name_buffer[0..entry.name.len], entry.name);
             result.name = self.name_buffer[0..entry.name.len];
             @memcpy(self.path_buffer[0..18], "/dev/serial/by-id/");
             @memcpy(self.path_buffer[18 .. 18 + entry.name.len], entry.name);
-            result.path = try std.fs.realpath(
+            const len = try std.Io.Dir.realPathFileAbsolute(
+                io,
                 self.path_buffer[0 .. entry.name.len + 18],
                 &self.path_buffer,
             );
+            result.path = self.path_buffer[0..len];
             return result;
         } else {
             return null;
         }
     }
 
-    pub fn deinit(self: *@This()) void {
+    pub fn deinit(self: *@This(), io: std.Io) void {
         if (self.dir) |*d| {
-            d.close();
+            d.close(io);
         }
         self.* = undefined;
     }
 };
 
 fn openVirtualPorts(
-    master_port: *std.fs.File,
-    slave_port: *std.fs.File,
+    io: std.Io,
+    master_port: *std.Io.File,
+    slave_port: *std.Io.File,
 ) !void {
     const c = @cImport({
         @cDefine("_XOPEN_SOURCE", "700");
@@ -228,8 +229,8 @@ fn openVirtualPorts(
         @cInclude("unistd.h");
     });
 
-    master_port.* = try open("/dev/ptmx", .{ .mode = .read_write });
-    errdefer master_port.close();
+    master_port.* = try open(io, "/dev/ptmx", .{ .mode = .read_write });
+    errdefer master_port.close(io);
 
     if (c.grantpt(master_port.handle) < 0 or
         c.unlockpt(master_port.handle) < 0)
@@ -242,17 +243,19 @@ fn openVirtualPorts(
         return error.SlavePseudoTerminalSetupError;
 
     slave_port.* = try open(
+        io,
         slave_name[0..slave_name_len],
         .{ .mode = .read_write },
     );
 }
 
 test "software flow control" {
-    var master: std.fs.File = undefined;
-    var slave: std.fs.File = undefined;
-    try openVirtualPorts(&master, &slave);
-    defer master.close();
-    defer slave.close();
+    const io = std.testing.io;
+    var master: std.Io.File = undefined;
+    var slave: std.Io.File = undefined;
+    try openVirtualPorts(io, &master, &slave);
+    defer master.close(io);
+    defer slave.close(io);
 
     const config: serialport.Config = .{
         .baud_rate = .B230400,
@@ -264,9 +267,9 @@ test "software flow control" {
     const orig_slave = try configure(slave, config);
     defer std.posix.tcsetattr(slave.handle, .NOW, orig_slave) catch {};
 
-    var master_w = master.writerStreaming(&.{});
+    var master_w = master.writerStreaming(io, &.{});
     var reader_buf: [128]u8 = undefined;
-    var slave_r = slave.readerStreaming(&reader_buf);
+    var slave_r = slave.readerStreaming(io, &reader_buf);
 
     try std.testing.expectError(
         error.EndOfStream,
@@ -313,11 +316,12 @@ test "software flow control" {
 }
 
 test {
-    var master: std.fs.File = undefined;
-    var slave: std.fs.File = undefined;
-    try openVirtualPorts(&master, &slave);
-    defer master.close();
-    defer slave.close();
+    const io = std.testing.io;
+    var master: std.Io.File = undefined;
+    var slave: std.Io.File = undefined;
+    try openVirtualPorts(io, &master, &slave);
+    defer master.close(io);
+    defer slave.close(io);
 
     const config: serialport.Config = .{ .baud_rate = .B115200 };
     const orig_master = try configure(master, config);
@@ -325,9 +329,9 @@ test {
     const orig_slave = try configure(slave, config);
     defer std.posix.tcsetattr(slave.handle, .NOW, orig_slave) catch {};
 
-    var master_w = master.writerStreaming(&.{});
+    var master_w = master.writerStreaming(io, &.{});
     var reader_buf: [128]u8 = undefined;
-    var slave_r = slave.readerStreaming(&reader_buf);
+    var slave_r = slave.readerStreaming(io, &reader_buf);
 
     try std.testing.expectError(
         error.EndOfStream,
@@ -373,11 +377,12 @@ test {
 }
 
 test "nonblock read" {
-    var master: std.fs.File = undefined;
-    var slave: std.fs.File = undefined;
-    try openVirtualPorts(&master, &slave);
-    defer master.close();
-    defer slave.close();
+    const io = std.testing.io;
+    var master: std.Io.File = undefined;
+    var slave: std.Io.File = undefined;
+    try openVirtualPorts(io, &master, &slave);
+    defer master.close(io);
+    defer slave.close(io);
 
     const config: serialport.Config = .{ .baud_rate = .B115200 };
     const orig_master = try configure(master, config);
@@ -386,7 +391,7 @@ test "nonblock read" {
     defer std.posix.tcsetattr(slave.handle, .NOW, orig_slave) catch {};
 
     var reader_buf: [128]u8 = undefined;
-    var slave_r = slave.readerStreaming(&reader_buf);
+    var slave_r = slave.readerStreaming(io, &reader_buf);
 
     var result: [16]u8 = undefined;
     try std.testing.expectEqual(
@@ -396,11 +401,12 @@ test "nonblock read" {
 }
 
 test "custom baud rate" {
-    var master: std.fs.File = undefined;
-    var slave: std.fs.File = undefined;
-    try openVirtualPorts(&master, &slave);
-    defer master.close();
-    defer slave.close();
+    const io = std.testing.io;
+    var master: std.Io.File = undefined;
+    var slave: std.Io.File = undefined;
+    try openVirtualPorts(io, &master, &slave);
+    defer master.close(io);
+    defer slave.close(io);
 
     const config: serialport.Config = .{ .baud_rate = @enumFromInt(7667) };
     const orig_master = try configure(master, config);
@@ -408,9 +414,9 @@ test "custom baud rate" {
     const orig_slave = try configure(slave, config);
     defer std.posix.tcsetattr(slave.handle, .NOW, orig_slave) catch {};
 
-    var master_w = master.writerStreaming(&.{});
+    var master_w = master.writerStreaming(io, &.{});
     var reader_buf: [128]u8 = undefined;
-    var slave_r = slave.readerStreaming(&reader_buf);
+    var slave_r = slave.readerStreaming(io, &reader_buf);
 
     try std.testing.expectError(
         error.EndOfStream,

--- a/src/backend/windows.zig
+++ b/src/backend/windows.zig
@@ -23,46 +23,80 @@ pub const BaudRate = enum(windows.DWORD) {
     _,
 };
 
+pub const OpenError = error{
+    IsDir,
+    NotDir,
+    FileNotFound,
+    NoDevice,
+    AccessDenied,
+    PipeBusy,
+    PathAlreadyExists,
+    Unexpected,
+    NameTooLong,
+    WouldBlock,
+    NetworkNotFound,
+    AntivirusInterference,
+    BadPathName,
+};
+
+const Wtf8ToWtf16Error = error{ BadPathName, NameTooLong };
+
+const WaitForSingleObjectError = error{
+    WaitAbandoned,
+    WaitTimeOut,
+    Unexpected,
+};
+
 pub const ReadError =
-    windows.ReadFileError ||
-    windows.OpenError ||
-    windows.Wtf8ToPrefixedFileWError ||
-    windows.WaitForSingleObjectError;
+    std.Io.File.Reader.Error ||
+    OpenError ||
+    Wtf8ToWtf16Error ||
+    WaitForSingleObjectError;
 pub const Reader = struct {
-    context: std.fs.File,
+    context: std.Io.File,
     /// Last error encountered by interface.
     err: ?windows.Win32Error = null,
     interface: std.Io.Reader,
 };
 pub const WriteError =
-    windows.WriteFileError ||
-    windows.OpenError ||
-    windows.Wtf8ToPrefixedFileWError ||
-    windows.WaitForSingleObjectError;
+    std.Io.File.Writer.Error ||
+    OpenError ||
+    Wtf8ToWtf16Error ||
+    WaitForSingleObjectError;
 pub const Writer = struct {
-    context: std.fs.File,
+    context: std.Io.File,
     /// Last error encountered by interface.
     err: ?windows.Win32Error = null,
     interface: std.Io.Writer,
 };
 
-pub fn open(path: []const u8, flags: std.fs.File.OpenFlags) !std.fs.File {
-    const path_w = try windows.sliceToPrefixedFileW(std.fs.cwd().fd, path);
+pub fn open(
+    _: std.Io,
+    path: []const u8,
+    flags: std.Io.File.OpenFlags,
+) (Wtf8ToWtf16Error || std.Io.Dir.RealPathFileError)!std.Io.File {
+    var path_wtf16: [windows.PATH_MAX_WIDE:0]u16 =
+        .{0} ** windows.PATH_MAX_WIDE;
+    const path_wtf16_len = try windows.wtf8ToWtf16Le(
+        &path_wtf16,
+        path,
+    );
     // TODO: Support other flags
-    const result: std.fs.File = .{
-        .handle = windows.kernel32.CreateFileW(
-            path_w.span(),
+    const result: std.Io.File = .{
+        .handle = CreateFileW(
+            path_wtf16[0..path_wtf16_len :0],
             switch (flags.mode) {
-                .read_only => windows.GENERIC_READ,
-                .write_only => windows.GENERIC_WRITE,
-                .read_write => windows.GENERIC_READ | windows.GENERIC_WRITE,
+                .read_only => GENERIC_READ,
+                .write_only => GENERIC_WRITE,
+                .read_write => GENERIC_READ | GENERIC_WRITE,
             },
             0,
             null,
-            windows.OPEN_EXISTING,
-            windows.FILE_FLAG_OVERLAPPED,
+            OPEN_EXISTING,
+            FILE_FLAG_OVERLAPPED,
             null,
         ),
+        .flags = .{ .nonblocking = true },
     };
     if (result.handle == windows.INVALID_HANDLE_VALUE) {
         switch (windows.GetLastError()) {
@@ -75,14 +109,14 @@ pub fn open(path: []const u8, flags: std.fs.File.OpenFlags) !std.fs.File {
     return result;
 }
 
-pub fn configure(port: std.fs.File, config: serialport.Config) !void {
+pub fn configure(port: std.Io.File, config: serialport.Config) !void {
     var dcb: DCB = std.mem.zeroes(DCB);
     dcb.DCBlength = @sizeOf(DCB);
 
     if (config.input_baud_rate != null)
         return error.InputBaudRateUnsupported;
 
-    if (GetCommState(port.handle, &dcb) == 0)
+    if (GetCommState(port.handle, &dcb) == .FALSE)
         return windows.unexpectedError(windows.GetLastError());
 
     dcb.BaudRate = config.baud_rate;
@@ -99,10 +133,10 @@ pub fn configure(port: std.fs.File, config: serialport.Config) !void {
     dcb.XonChar = 0x11;
     dcb.XoffChar = 0x13;
 
-    if (SetCommState(port.handle, &dcb) == 0) {
+    if (SetCommState(port.handle, &dcb) == .FALSE) {
         return windows.unexpectedError(windows.GetLastError());
     }
-    if (SetCommMask(port.handle, .{ .RXCHAR = true }) == 0) {
+    if (SetCommMask(port.handle, .{ .RXCHAR = true }) == .FALSE) {
         return windows.unexpectedError(windows.GetLastError());
     }
     const timeouts: CommTimeouts = .{
@@ -112,12 +146,12 @@ pub fn configure(port: std.fs.File, config: serialport.Config) !void {
         .WriteTotalTimeoutMultiplier = 0,
         .WriteTotalTimeoutConstant = 0,
     };
-    if (SetCommTimeouts(port.handle, &timeouts) == 0) {
+    if (SetCommTimeouts(port.handle, &timeouts) == .FALSE) {
         return windows.unexpectedError(windows.GetLastError());
     }
 }
 
-pub fn reader(port: std.fs.File, buffer: []u8) Reader {
+pub fn reader(port: std.Io.File, buffer: []u8) Reader {
     return .{
         .context = port,
         .interface = .{
@@ -129,7 +163,7 @@ pub fn reader(port: std.fs.File, buffer: []u8) Reader {
     };
 }
 
-pub fn writer(port: std.fs.File, buffer: []u8) Writer {
+pub fn writer(port: std.Io.File, buffer: []u8) Writer {
     return .{
         .context = port,
         .interface = .{
@@ -141,9 +175,9 @@ pub fn writer(port: std.fs.File, buffer: []u8) Writer {
     };
 }
 
-pub fn iterate() !Iterator {
+pub fn iterate(_: std.Io) !Iterator {
     const HKEY_LOCAL_MACHINE = @as(windows.HKEY, @ptrFromInt(0x80000002));
-    const KEY_READ = 0x20019;
+    const KEY_READ: @typeInfo(std.os.windows.REGSAM).@"struct".backing_integer.? = 0x20019;
 
     const w_str: [30:0]u16 = .{
         'H',
@@ -179,11 +213,11 @@ pub fn iterate() !Iterator {
     };
 
     var result: Iterator = .{ .key = undefined };
-    if (windows.advapi32.RegOpenKeyExW(
+    if (RegOpenKeyExW(
         HKEY_LOCAL_MACHINE,
         &w_str,
         0,
-        KEY_READ,
+        @bitCast(KEY_READ),
         &result.key,
     ) != 0) {
         switch (windows.GetLastError()) {
@@ -201,7 +235,7 @@ pub const Iterator = struct {
     name_buffer: [16]u8 = undefined,
     path_buffer: [16]u8 = undefined,
 
-    pub fn next(self: *@This()) !?serialport.Stub {
+    pub fn next(self: *@This(), _: std.Io) !?serialport.Stub {
         defer self.index += 1;
 
         var name_size: windows.DWORD = 256;
@@ -231,8 +265,8 @@ pub const Iterator = struct {
         };
     }
 
-    pub fn deinit(self: *@This()) void {
-        _ = windows.advapi32.RegCloseKey(self.key);
+    pub fn deinit(self: *@This(), _: std.Io) void {
+        _ = RegCloseKey(self.key);
         self.* = undefined;
     }
 };
@@ -244,7 +278,7 @@ fn stream(
 ) std.Io.Reader.StreamError!usize {
     if (!limit.nonzero()) return 0;
     const port_reader: *Reader = @fieldParentPtr("interface", r);
-    var overlapped: windows.OVERLAPPED = .{
+    var overlapped: OVERLAPPED = .{
         .Internal = 0,
         .InternalHigh = 0,
         .DUMMYUNIONNAME = .{
@@ -253,19 +287,20 @@ fn stream(
                 .OffsetHigh = 0,
             },
         },
-        .hEvent = windows.CreateEventEx(
+        .hEvent = CreateEventEx(
             null,
             "",
-            windows.CREATE_EVENT_MANUAL_RESET,
-            windows.EVENT_ALL_ACCESS,
+            CREATE_EVENT_MANUAL_RESET,
+            EVENT_ALL_ACCESS,
         ) catch |e| {
-            port_reader.err = switch (e) {
-                error.AccessDenied => .ACCESS_DENIED,
-                error.BadPathName => .BAD_PATHNAME,
-                error.FileNotFound => .FILE_NOT_FOUND,
-                error.InvalidWtf8, error.NameTooLong => .BAD_PATHNAME,
-                error.Unexpected => windows.GetLastError(),
-            };
+            switch (e) {
+                error.BadPathName, error.NameTooLong => {
+                    port_reader.err = .BAD_PATHNAME;
+                },
+                else => {
+                    port_reader.err = windows.GetLastError();
+                },
+            }
             return error.ReadFailed;
         },
     };
@@ -284,13 +319,13 @@ fn stream(
         buf.len,
     );
     var read_amount: windows.DWORD = undefined;
-    if (windows.kernel32.ReadFile(
+    if (ReadFile(
         port_reader.context.handle,
         buf.ptr,
         want_read_count,
         &read_amount,
         &overlapped,
-    ) == 0) {
+    ) == .FALSE) {
         switch (windows.GetLastError()) {
             windows.Win32Error.IO_PENDING => {},
             else => |e| {
@@ -307,12 +342,12 @@ fn stream(
     }
 
     var async_read_amount: windows.DWORD = undefined;
-    if (windows.kernel32.GetOverlappedResult(
+    if (GetOverlappedResult(
         port_reader.context.handle,
         &overlapped,
         &async_read_amount,
-        0,
-    ) != 0) {
+        .FALSE,
+    ) != .FALSE) {
         if (async_read_amount == 0) {
             // Must return EOS when there are no bytes left.
             port_reader.err = null;
@@ -320,12 +355,12 @@ fn stream(
         }
         return async_read_amount;
     }
-    if (windows.kernel32.GetOverlappedResult(
+    if (GetOverlappedResult(
         port_reader.context.handle,
         &overlapped,
         &async_read_amount,
-        1,
-    ) == 0) {
+        .TRUE,
+    ) == .FALSE) {
         switch (windows.GetLastError()) {
             .HANDLE_EOF => {
                 port_reader.err = null;
@@ -383,7 +418,7 @@ fn drainBuffer(
     bytes: []const u8,
 ) !usize {
     var bytes_written: windows.DWORD = undefined;
-    var overlapped: windows.OVERLAPPED = .{
+    var overlapped: OVERLAPPED = .{
         .Internal = 0,
         .InternalHigh = 0,
         .DUMMYUNIONNAME = .{
@@ -392,19 +427,20 @@ fn drainBuffer(
                 .OffsetHigh = 0,
             },
         },
-        .hEvent = windows.CreateEventEx(
+        .hEvent = CreateEventEx(
             null,
             "",
-            windows.CREATE_EVENT_MANUAL_RESET,
-            windows.EVENT_ALL_ACCESS,
+            CREATE_EVENT_MANUAL_RESET,
+            EVENT_ALL_ACCESS,
         ) catch |e| {
-            port_writer.err = switch (e) {
-                error.AccessDenied => .ACCESS_DENIED,
-                error.BadPathName => .BAD_PATHNAME,
-                error.FileNotFound => .FILE_NOT_FOUND,
-                error.InvalidWtf8, error.NameTooLong => .BAD_PATHNAME,
-                error.Unexpected => windows.GetLastError(),
-            };
+            switch (e) {
+                error.BadPathName, error.NameTooLong => {
+                    port_writer.err = .BAD_PATHNAME;
+                },
+                else => {
+                    port_writer.err = windows.GetLastError();
+                },
+            }
             return error.ReadFailed;
         },
     };
@@ -412,13 +448,13 @@ fn drainBuffer(
     const adjusted_len =
         std.math.cast(u32, bytes.len) orelse std.math.maxInt(u32);
 
-    if (windows.kernel32.WriteFile(
+    if (WriteFile(
         port_writer.context.handle,
         bytes.ptr,
         adjusted_len,
         &bytes_written,
         &overlapped,
-    ) == 0) {
+    ) == .FALSE) {
         port_writer.err = windows.GetLastError();
         switch (port_writer.err.?) {
             .INVALID_USER_BUFFER => return error.SystemResources,
@@ -426,11 +462,11 @@ fn drainBuffer(
             .OPERATION_ABORTED => return error.OperationAborted,
             .NOT_ENOUGH_QUOTA => return error.SystemResources,
             .IO_PENDING => {
-                try windows.WaitForSingleObject(
+                try WaitForSingleObject(
                     overlapped.hEvent.?,
-                    windows.INFINITE,
+                    INFINITE,
                 );
-                const amount_written = try windows.GetOverlappedResult(
+                const amount_written = try GetOverlappedResultWrapper(
                     port_writer.context.handle,
                     &overlapped,
                     true,
@@ -559,7 +595,7 @@ extern "kernel32" fn SetCommTimeouts(
 extern "kernel32" fn WaitCommEvent(
     hFile: windows.HANDLE,
     lpEvtMask: *EventMask,
-    lpOverlapped: ?*windows.OVERLAPPED,
+    lpOverlapped: ?*OVERLAPPED,
 ) callconv(.winapi) windows.BOOL;
 
 extern "kernel32" fn ClearCommError(
@@ -589,3 +625,144 @@ extern "advapi32" fn RegEnumValueA(
     lpData: [*]windows.BYTE,
     lpcbData: *windows.DWORD,
 ) callconv(.winapi) std.os.windows.LSTATUS;
+
+extern "advapi32" fn RegOpenKeyExW(
+    hKey: windows.HKEY,
+    lpSubKey: windows.LPCWSTR,
+    ulOptions: windows.DWORD,
+    samDesired: windows.REGSAM,
+    phkResult: *windows.HKEY,
+) callconv(.winapi) windows.LSTATUS;
+
+extern "advapi32" fn RegCloseKey(
+    hKey: windows.HKEY,
+) callconv(.winapi) windows.LSTATUS;
+
+extern "kernel32" fn CreateFileW(
+    lpFileName: windows.LPCWSTR,
+    dwDesiredAccess: windows.DWORD,
+    dwShareMode: windows.DWORD,
+    lpSecurityAttributes: ?*windows.SECURITY_ATTRIBUTES,
+    dwCreationDisposition: windows.DWORD,
+    dwFlagsAndAttributes: windows.DWORD,
+    hTemplateFile: ?windows.HANDLE,
+) callconv(.winapi) windows.HANDLE;
+
+pub extern "kernel32" fn WaitForSingleObjectEx(
+    hHandle: windows.HANDLE,
+    dwMilliseconds: windows.DWORD,
+    bAlertable: windows.BOOL,
+) callconv(.winapi) windows.DWORD;
+
+const WAIT_ABANDONED = 0x00000080;
+const WAIT_ABANDONED_0 = WAIT_ABANDONED + 0;
+const WAIT_OBJECT_0 = 0x00000000;
+const WAIT_TIMEOUT = 0x00000102;
+const WAIT_FAILED = 0xFFFFFFFF;
+
+const GENERIC_READ = 0x80000000;
+const GENERIC_WRITE = 0x40000000;
+
+const OPEN_EXISTING = 3;
+const FILE_FLAG_OVERLAPPED = 0x40000000;
+const CREATE_EVENT_MANUAL_RESET = 0x00000001;
+const EVENT_ALL_ACCESS = 0x1F0003;
+
+const INFINITE = 4294967295;
+
+pub fn WaitForSingleObject(
+    handle: windows.HANDLE,
+    milliseconds: windows.DWORD,
+) WaitForSingleObjectError!void {
+    switch (WaitForSingleObjectEx(handle, milliseconds, .FALSE)) {
+        WAIT_ABANDONED => return error.WaitAbandoned,
+        WAIT_OBJECT_0 => return,
+        WAIT_TIMEOUT => return error.WaitTimeOut,
+        WAIT_FAILED => switch (windows.GetLastError()) {
+            else => |err| return windows.unexpectedError(err),
+        },
+        else => return error.Unexpected,
+    }
+}
+
+pub const OVERLAPPED = extern struct {
+    Internal: windows.ULONG_PTR,
+    InternalHigh: windows.ULONG_PTR,
+    DUMMYUNIONNAME: extern union {
+        DUMMYSTRUCTNAME: extern struct {
+            Offset: windows.DWORD,
+            OffsetHigh: windows.DWORD,
+        },
+        Pointer: ?windows.PVOID,
+    },
+    hEvent: ?windows.HANDLE,
+};
+
+fn CreateEventEx(
+    attributes: ?*windows.SECURITY_ATTRIBUTES,
+    name: []const u8,
+    flags: windows.DWORD,
+    desired_access: windows.DWORD,
+) (Wtf8ToWtf16Error || error{Unexpected})!windows.HANDLE {
+    var path: [windows.PATH_MAX_WIDE:0]u16 =
+        .{0} ** windows.PATH_MAX_WIDE;
+    const path_len = try windows.wtf8ToWtf16Le(&path, name);
+    const handle = CreateEventExW(
+        attributes,
+        path[0..path_len :0],
+        flags,
+        desired_access,
+    );
+    if (handle) |h| {
+        return h;
+    } else {
+        switch (windows.GetLastError()) {
+            else => |err| return windows.unexpectedError(err),
+        }
+    }
+}
+
+extern "kernel32" fn CreateEventExW(
+    lpEventAttributes: ?*windows.SECURITY_ATTRIBUTES,
+    lpName: ?windows.LPCWSTR,
+    dwFlags: windows.DWORD,
+    dwDesiredAccess: windows.DWORD,
+) callconv(.winapi) ?windows.HANDLE;
+
+extern "kernel32" fn ReadFile(
+    hFile: windows.HANDLE,
+    lpBuffer: windows.LPVOID,
+    nNumberOfBytesToRead: windows.DWORD,
+    lpNumberOfBytesRead: ?*windows.DWORD,
+    lpOverlapped: ?*OVERLAPPED,
+) callconv(.winapi) windows.BOOL;
+
+extern "kernel32" fn WriteFile(
+    in_hFile: windows.HANDLE,
+    in_lpBuffer: [*]const u8,
+    in_nNumberOfBytesToWrite: windows.DWORD,
+    out_lpNumberOfBytesWritten: ?*windows.DWORD,
+    in_out_lpOverlapped: ?*OVERLAPPED,
+) callconv(.winapi) windows.BOOL;
+
+extern "kernel32" fn GetOverlappedResult(
+    hFile: windows.HANDLE,
+    lpOverlapped: *OVERLAPPED,
+    lpNumberOfBytesTransferred: *windows.DWORD,
+    bWait: windows.BOOL,
+) callconv(.winapi) windows.BOOL;
+
+pub fn GetOverlappedResultWrapper(
+    h: windows.HANDLE,
+    overlapped: *OVERLAPPED,
+    wait: bool,
+) !windows.DWORD {
+    var bytes: windows.DWORD = undefined;
+    if (GetOverlappedResult(h, overlapped, &bytes, .fromBool(wait)) == .FALSE) {
+        switch (windows.GetLastError()) {
+            .IO_INCOMPLETE => if (!wait) return error.WouldBlock else unreachable,
+            else => |err| return windows.unexpectedError(err),
+        }
+    }
+    return bytes;
+}

--- a/src/serialport.zig
+++ b/src/serialport.zig
@@ -6,17 +6,17 @@ pub const linux = @import("backend/linux.zig");
 pub const macos = @import("backend/macos.zig");
 pub const windows = @import("backend/windows.zig");
 
-pub fn iterate() !Iterator {
+pub fn iterate(io: std.Io) !Iterator {
     switch (builtin.target.os.tag) {
-        .linux, .macos, .windows => return backend.iterate(),
+        .linux, .macos, .windows => return backend.iterate(io),
         else => @compileError("unsupported OS"),
     }
 }
 
-pub fn open(file_path: []const u8, flags: std.fs.File.OpenFlags) !Port {
+pub fn open(io: std.Io, file_path: []const u8, flags: std.Io.File.OpenFlags) !Port {
     return switch (builtin.target.os.tag) {
         .linux, .macos, .windows => .{ ._impl = .{
-            .file = try backend.open(file_path, flags),
+            .file = try backend.open(io, file_path, flags),
         } },
         else => @compileError("unsupported OS"),
     };
@@ -24,11 +24,11 @@ pub fn open(file_path: []const u8, flags: std.fs.File.OpenFlags) !Port {
 
 const PortImpl = switch (builtin.target.os.tag) {
     .linux, .macos => struct {
-        file: std.fs.File,
+        file: std.Io.File,
         orig_termios: ?std.posix.termios = null,
     },
     .windows => struct {
-        file: std.fs.File,
+        file: std.Io.File,
     },
     else => @compileError("unsupported OS"),
 };
@@ -37,27 +37,27 @@ pub const Port = struct {
     _impl: PortImpl,
 
     pub const Reader = switch (builtin.target.os.tag) {
-        .linux, .macos => std.fs.File.Reader,
+        .linux, .macos => std.Io.File.Reader,
         .windows => windows.Reader,
         else => @compileError("unsupported OS"),
     };
     pub const ReadError = switch (builtin.target.os.tag) {
-        .linux, .macos => std.fs.File.ReadError,
+        .linux, .macos => std.Io.File.Reader.Error,
         .windows => windows.ReadError,
         else => @compileError("unsupported OS"),
     };
     pub const Writer = switch (builtin.target.os.tag) {
-        .linux, .macos => std.fs.File.Writer,
+        .linux, .macos => std.Io.File.Writer,
         .windows => windows.Writer,
         else => @compileError("unsupported OS"),
     };
     pub const WriteError = switch (builtin.target.os.tag) {
-        .linux, .macos => std.fs.File.WriteError,
+        .linux, .macos => std.Io.File.Writer.Error,
         .windows => windows.WriteError,
         else => @compileError("unsupported OS"),
     };
 
-    pub fn close(self: *@This()) void {
+    pub fn close(self: *@This(), io: std.Io) void {
         switch (comptime builtin.target.os.tag) {
             .linux, .macos => {
                 if (self._impl.orig_termios) |orig_termios| {
@@ -67,10 +67,10 @@ pub const Port = struct {
                         orig_termios,
                     ) catch {};
                 }
-                self._impl.file.close();
+                self._impl.file.close(io);
             },
             .windows => {
-                self._impl.file.close();
+                self._impl.file.close(io);
             },
             else => @compileError("unsupported OS"),
         }
@@ -95,17 +95,23 @@ pub const Port = struct {
         }
     }
 
-    pub fn reader(self: @This(), buffer: []u8) Reader {
+    pub fn reader(self: @This(), io: std.Io, buffer: []u8) Reader {
         switch (comptime builtin.target.os.tag) {
-            .linux, .macos => return self._impl.file.readerStreaming(buffer),
+            .linux, .macos => return self._impl.file.readerStreaming(
+                io,
+                buffer,
+            ),
             .windows => return windows.reader(self._impl.file, buffer),
             else => @compileError("unsupported OS"),
         }
     }
 
-    pub fn writer(self: @This(), buffer: []u8) Writer {
+    pub fn writer(self: @This(), io: std.Io, buffer: []u8) Writer {
         switch (comptime builtin.target.os.tag) {
-            .linux, .macos => return self._impl.file.writerStreaming(buffer),
+            .linux, .macos => return self._impl.file.writerStreaming(
+                io,
+                buffer,
+            ),
             .windows => return windows.writer(self._impl.file, buffer),
             else => @compileError("unsupported OS"),
         }
@@ -191,8 +197,8 @@ pub const Stub = struct {
     name: []const u8,
     path: []const u8,
 
-    pub fn open(self: @This(), flags: std.fs.File.OpenFlags) !Port {
-        return serialport.open(self.path, flags);
+    pub fn open(self: @This(), io: std.Io, flags: std.Io.File.OpenFlags) !Port {
+        return serialport.open(io, self.path, flags);
     }
 };
 
@@ -209,10 +215,11 @@ const backend = switch (builtin.target.os.tag) {
 };
 
 test {
+    const io = std.testing.io;
     std.testing.refAllDecls(Port);
     std.testing.refAllDecls(Iterator);
     std.testing.refAllDecls(Stub);
-    _ = try iterate();
+    _ = try iterate(io);
 
     switch (builtin.target.os.tag) {
         .linux => std.testing.refAllDecls(linux),


### PR DESCRIPTION
I decided to upstream the changes for the library to be working on zig 0.16.0. However, required kernel32 functions are added manually since changing it with ntdll will surely takes more time for updating it.